### PR TITLE
chore: add SonarQube scan pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,5 +1,5 @@
 - name: cli-plugin-edition
-  referenceId: PLACEHOLDER
+  referenceId: 1EO1C093
   build:
     provider: dkcicd
     pipelines:

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,7 +1,22 @@
 - name: cli-plugin-edition
+  referenceId: PLACEHOLDER
   build:
     provider: dkcicd
     pipelines:
+      - name: node-ci-v2
+        parameters:
+          sonarProjectName: cli-plugin-edition
+          nodeVersion: 20-bookworm
+          nodeCommands:
+            - test -- --passWithNoTests --coverage
+        runtime:
+          architecture: amd64
+        when:
+          - event: pull_request
+            source: branch
+          - event: push
+            source: branch
+            regex: master
       - name: techdocs-v1
         parameters:
           entityReference: default/component/cli-plugin-edition


### PR DESCRIPTION
## Summary
- Adds a `node-ci-v2` pipeline to enable SonarQube code quality scanning
- Configures test coverage output for SonarQube consumption
- Triggers on pull requests for PR decoration (quality gate comments)

## Context
Part of a rollout to enable SonarQube across VTEX repositories. Runs alongside existing CI pipelines.

## Test plan
- [ ] Pipeline runs successfully on this PR
- [ ] SonarQube project appears at http://sonarqube.vtex.systems/
- [ ] PR decoration (quality gate comment) appears